### PR TITLE
adds a sketch for T-slot nuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ A list of all the fragments currently recognised:
 | nut_profile       | Rectangle with two horizontal lines, as the side view of a hex nut. |
 | locknut_profile   | Rectangle with two horizontal lines, as the side view of a hex nut, with an added "top bump". |
 | lockwasher        | Circular washer with a locking cutout.                            |
+| tnut              | T-slot nut, rectangular horizontal profile                        |
 | magnet            | Horseshoe shaped magnet symbol.                                   |
 | measure           | Fills as much area as possible with a dimension line, and shows the length. Useful for debugging. |
 | sym, symbol       | Render an electronic symbol.                                      |

--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -31,6 +31,7 @@ from build123d import (
     PolarLocations,
     Polyline,
     Rectangle,
+    RectangleRounded,
     RegularPolygon,
     Rot,
     Sketch,
@@ -453,6 +454,16 @@ def _fragment_circle(height: float, _maxsize: float) -> Sketch:
     """A filled circle."""
     with BuildSketch(mode=Mode.PRIVATE) as sketch:
         Circle(height / 2)
+    return sketch.sketch
+
+
+@fragment("tnut", examples=["{tnut}"])
+def _fragment_tnut(height: float, _maxsize: float) -> Sketch:
+    """T-slot nut."""
+    with BuildSketch(mode=Mode.PRIVATE) as sketch:
+        RectangleRounded(height*0.6, height, height/7)
+        Circle((height*0.4)/2, mode=Mode.SUBTRACT)
+
     return sketch.sketch
 
 


### PR DESCRIPTION
This is a simple horizontal profile of a T-nut. A rounded rectangle with a hole in the middle.