### PR TITLE
implement overall scale factors for when you need a little nudge 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The full command parameter usage (as generate by `gflabel --help`):
 usage: gflabel [-h] [--vscode] [-w WIDTH] [--height HEIGHT] [--depth DEPTH_MM] [--no-overheight] [-d DIVISIONS] [--font FONT]
                [--font-size-maximum FONT_SIZE_MAXIMUM | --font-size FONT_SIZE] [--font-style {regular,bold,italic}] [--font-path FONT_PATH]
                [--margin MARGIN] [-o OUTPUT] [--style {embossed,debossed,embedded}] [--list-fragments] [--list-symbols] [--label-gap LABEL_GAP]
-               [--column-gap COLUMN_GAP] [-v] [--version VERSION]
+               [--column-gap COLUMN_GAP] [--xscale XSCALE] [--yscale YSCALE] [--zscale ZSCALE] [-v] [--version VERSION]
                BASE LABEL [LABEL ...]
 
 Generate gridfinity bin labels
@@ -166,6 +166,9 @@ options:
                         Vertical gap (in mm) between physical labels. Default: 2 mm
   --column-gap COLUMN_GAP
                         Gap (in mm) between columns
+  --xscale,--yscale,--zscale
+                        Scale factor for entire label along the corresponding axis. Useful when you need slight adjustments for proper fit.
+                        [All default to 1.0]
   -v, --verbose         Verbose output
   --version VERSION     The version of geometry to use for a given label system (if a system has versions). [Default: latest]
 ```

--- a/src/gflabel/cli.py
+++ b/src/gflabel/cli.py
@@ -34,6 +34,7 @@ from build123d import (
     add,
     export_step,
     extrude,
+    scale,
 )
 
 from . import fragments
@@ -284,6 +285,15 @@ def run(argv: list[str] | None = None):
     parser.add_argument(
         "--column-gap", help="Gap (in mm) between columns", default=0.4, type=float
     )
+    parser.add_argument(
+        "--xscale", help="Scale factor for entire label on the X axis", default=1.0, type=float
+    )
+    parser.add_argument(
+        "--yscale", help="Scale factor for entire label on the Y axis", default=1.0, type=float
+    )
+    parser.add_argument(
+        "--zscale", help="Scale factor for entire label on the Z axis", default=1.0, type=float
+    )
     parser.add_argument("--box", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("-v", "--verbose", help="Verbose output", action="store_true")
     parser.add_argument(
@@ -423,6 +433,8 @@ def run(argv: list[str] | None = None):
         assembly = Compound([part.part, embedded_label])
     else:
         assembly = Compound(part.part)
+
+    assembly = scale(assembly, (args.xscale, args.yscale, args.zscale))
 
     for output in args.output:
         if output.endswith(".stl"):


### PR DESCRIPTION
Sometimes the container into which the label will go isn't quite on the same page as gflabel, and you need a little bit of scaling for a better fit. For example, gflabel produces "pred" labels that are 0.8mm thick, but a container generator I use leaves tab slots that want tabs that are only 0.6mm thick. So, I apply "--zscale 0.75".

The three new command line arguments "--xscale", "--yscale", and "--zscale" can be used independently, and all default to 1.0, making them optional.