### PR TITLE
Colors

### DIFF
--- a/COLOR_NOTES.md
+++ b/COLOR_NOTES.md
@@ -1,0 +1,99 @@
+# Color Notes
+
+## Basics
+
+There are global default colors for the base and label,
+set via `--base-color` and `--label-color`, respectively.
+They default to `orange` and `blue`.
+Colors can be any of the names standardized in CSS3.
+
+In addition, there is a label fragment type for changing colors within a label.
+Each line of a label starts with the default label color.
+When a color fragment is seen, 
+all fragments after that will be rendered in the named color
+until another color fragment is seen or the end of the line is reached.
+
+Here are some examples.
+They are all rendered in VScode OCP CAD Viewer.
+For each example, a label with just the default colors
+is shown along with the same label using colors.
+
+## Slicers
+
+`gflabel` can produce STL and STEP output files.
+STL format is not color-aware.
+STEP format can handle colors,
+and the colors described here are part of the STEP file export from `gflabel`.
+However, treatment of color information when a STEP file is imported into a slicer varies a bit.
+In general, most slicers don't bother with STEP file colors on import.
+(Most CAD tools do, which is not surprising since STEP is a CAD file format.)
+
+Most color testing was done with Bambu Studio.
+It does not notice colors in STEP files.
+However, Bambu Studio does notice colors in OBJ and 3MF files,
+though it deals with them differently.
+The file converter at
+[convert3d.org](https://convert3d.org)
+can convert a STEP file into an OBJ or 3MF file that has colors expressed in a way that Bambu Studio understands.
+
+If you open one of those 3MF files in Bambu Studio,
+you will immediately see it rendered in the expected colors.
+Since those are just color names and not specific filaments,
+Bambu Studio will prompt you to map the colors to filaments
+when you try to send the sliced model to the 3D printer.
+
+If you open one of those OBJ files
+(and its accompanying MTL file)
+in Bambu Studio, you are immediately prompted to confirm or modify
+the color mapping choices it has made.
+But, again, you must map the colors to specific filaments
+when you try to send the sliced model to the 3D printer.
+
+## Examples
+
+Here is a very simple example:
+
+> gflabel --style embossed pred 'R{|}G{|}B' '{color(red)}R{|}{color(green)}G{|}{color(blue)}B' --vscode
+
+<img width="1425" height="808" alt="rgb" src="https://github.com/user-attachments/assets/bdf9bc30-611a-4821-ae2b-b6b599f9f24a" />
+
+Nobody is likely to have more than a few colors when 3D printing labels,
+but there is no enforced limit.
+Here's a slightly more complicated example:
+
+> gflabel --style embossed pred '{washer} R O Y G B I V {nut}' '{color(chartreuse)}{washer} {color(red)}R {color(orange)}O {color(yellow)}Y {color(green)}G {color(blue)}B {color(indigo)}I {color(violet)}V {color(chartreuse)}{nut}' --vscode
+
+<img width="1205" height="667" alt="image" src="https://github.com/user-attachments/assets/55b0a371-4f9d-49ad-8c9a-26ab936ce644" />
+
+This is an example of a divided label:
+
+> gflabel --style embossed pred '{<}I used to\nbe an\nadventurer\nlike you,{|}{variable_resistor}{|}{<}but\nthen....' '{<}I used to\nbe an\nadventurer\nlike you,{|}{color(red)}{variable_resistor}{|}{<}but\nthen....' --vscode
+
+<img width="1431" height="792" alt="adventurer" src="https://github.com/user-attachments/assets/0a64d9da-2006-4b1f-9e1d-4c65d6007da8" />
+
+Another example:
+
+> gflabel --style embossed pred 'Danger! {head(triangle)}' '{color(red)}Danger! {color(black)}{head(triangle)}' --vscode
+
+<img width="1425" height="814" alt="danger" src="https://github.com/user-attachments/assets/ae580ace-a1fc-4b2b-acdd-76f9ecee2502" />
+
+The color fragment should work properly with all of the other fragment types since there is no nesting.
+Here is one of the `{measure}` examples from the README:
+
+> gflabel predbox -w=5 'A\n{measure}{4|}B\n{measure}{1|2}C\n{measure}' 'A\n{color(white)}{measure}{4|}B\n{color(chartreuse)}{measure}{1|2}C\n{color(pink)}{measure}' --vscode
+
+<img width="1439" height="914" alt="measure" src="https://github.com/user-attachments/assets/9571c2fd-d5ed-45e5-a8fd-9e503303d23f" />
+
+There is one side effect that you might not expect.
+If you change the color inside a text fragment, 
+the spacing is likely to be affected.
+It's because rendering an uninterrupted text fragment is done
+with the assistance of low-level font handling code.
+When that same piece of text is broken into two or more
+pieces, the spacing between them is handled directly by
+the `gflabel` code.
+
+> gflabel --style embossed pred 'WWW' 'W{color(blue)}W{color(blue)}W' --vscode
+
+<img width="1423" height="805" alt="www" src="https://github.com/user-attachments/assets/4bdbb5df-d27a-4af5-bfc1-009429fa0d60" />
+

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The full command parameter usage (as generate by `gflabel --help`):
 ```
 usage: gflabel [-h] [--vscode] [-w WIDTH] [--height HEIGHT] [--label-depth DEPTH] [--depth DEPTH_MM] [--no-overheight] [-d DIVISIONS] [--font FONT]
                [--font-size-maximum FONT_SIZE_MAXIMUM | --font-size FONT_SIZE] [--font-style {regular,bold,italic,bolditalic}] [--font-path FONT_PATH]
-               [--margin MARGIN] [-o OUTPUT] [--style {embossed,debossed,embedded}] [--base-color BASE_COLOR] [--label-color LABEL_COLOR] [--list-fragments]
-               [--list-symbols] [--label-gap LABEL_GAP] [--column-gap COLUMN_GAP] [-v] [--version VERSION]
+               [--margin MARGIN] [-o OUTPUT] [--style {embossed,debossed,embedded}] [--base-color BASE_COLOR] [--label-color LABEL_COLOR] [--svg-mono]
+               [--list-fragments] [--list-symbols] [--label-gap LABEL_GAP] [--column-gap COLUMN_GAP] [-v] [--version VERSION]
                BASE LABEL [LABEL ...]
 
 Generate gridfinity bin labels
@@ -162,10 +162,12 @@ options:
   --style {embossed,debossed,embedded}
                         How the label contents are formed.
   --base-color BASE_COLOR
-                        The name of a color used for rendering the base. Can be any of the recognized OCCT color names. Default: %(default)s.
+                        The name of a color used for rendering the base. Can be any of the recognized CSS3 color names.
   --label-color LABEL_COLOR
-                        The name of a color used for rendering the label contents. Can be any of the recognized OCCT color names. Ignored for style
-                        'debossed' (except for 'vscode' rendering). Default: %(default)s.
+                        The name of a color used for rendering the label contents. Can be any of the recognized CSS3 color names. Ignored for style
+                        'debossed'.
+  --svg-mono            SVG files are normally produced with the same colors as the label contents. If you specify this argument, they are produced with label
+                        contents in the default label color.
   --list-fragments      List all available fragments.
   --list-symbols        List all available electronic symbols
   --label-gap LABEL_GAP
@@ -258,6 +260,7 @@ A list of all the fragments currently recognised:
 | bolt              | Variable length bolt, in the style of Printables pred-box labels.<br><br>If the requested bolt is longer than the available space, then the<br>bolt will be as large as possible with a broken thread. |
 | box               | Arbitrary width, height centered box. If height is not specified, will expand to row height. |
 | circle            | A filled circle.                                                  |
+| color             | Changes the color to be used for subsequent label fragments on a line (left to right). Every line starts with the default label color. See COLOR_NOTES.md
 | head              | Screw head with specifiable head-shape.                           |
 | hexhead           | Hexagonal screw head. Will accept drives, but not compulsory.     |
 | hexnut, nut       | Hexagonal outer profile nut with circular cutout.                 |

--- a/src/gflabel/cli.py
+++ b/src/gflabel/cli.py
@@ -21,7 +21,6 @@ from build123d import (
     BuildPart,
     BuildSketch,
     Color,
-    ColorIndex,
     Compound,
     ExportSVG,
     FontStyle,
@@ -29,11 +28,14 @@ from build123d import (
     Location,
     Locations,
     Mode,
+    Part,
     Plane,
     RectangleRounded,
+    Solid,
     Vector,
     add,
     export_step,
+    export_stl,
     extrude,
 )
 
@@ -154,6 +156,27 @@ def base_name_to_subclass(name: str) -> type[LabelBase]:
     return bases[name]
 
 
+def colored_parts(comp: Compound) -> list(Part):
+    """Walk the tree of comp to get a list of individual Part objects. Adjust their local locatons to globals along the way."""
+    part_list = []
+    for child in comp.children:
+        if isinstance(child, Part):
+            # we clone the part so that the move() calls don't modify things in place
+            clone = Part(child)
+            clone.label = child.label
+            clone.color = child.color
+            clone.move(comp.location)
+            part_list.append(clone)
+        elif isinstance(child, Compound):
+            child_part_list = colored_parts(child)
+            for child_part in child_part_list:
+                clone_part = Part(child_part)
+                clone_part.label = child_part.label
+                clone_part.color = child_part.color
+                clone_part.move(comp.location)
+                part_list.append(clone_part)
+    return part_list
+
 def run(argv: list[str] | None = None):
     # Handle the old way of specifying base
     if any((x.startswith("--base") and x != "--base-color") for x in (argv or sys.argv)):
@@ -268,15 +291,21 @@ def run(argv: list[str] | None = None):
     )
     parser.add_argument(
         "--base-color",
-        help="The name of a color used for rendering the base. Can be any of the recognized OCCT color names.",
+        help="The name of a color used for rendering the base. Can be any of the recognized CSS3 color names.",
         type=str,
         default="orange",
     )
     parser.add_argument(
         "--label-color",
-        help="The name of a color used for rendering the label contents. Can be any of the recognized OCCT color names. Ignored for style 'debossed'.",
+        help="The name of a color used for rendering the label contents. Can be any of the recognized CSS3 color names. Ignored for style 'debossed'.",
         type=str,
         default="blue",
+    )
+    parser.add_argument(
+        "--svg-mono",
+        help="SVG files are normally produced with the same colors as the label contents. If you specify this argument, they are produced with label contents in the default label color.",
+        action="store_true",
+        default=False,
     )
     parser.add_argument(
         "--list-fragments",
@@ -367,7 +396,7 @@ def run(argv: list[str] | None = None):
     options = RenderOptions.from_args(args)
     logger.debug("Got render options: %s", options)
     body: LabelBase | None = None
-    with BuildPart() as part:
+    with BuildPart() as base_bpart:
         y = 0
         body = base_type(args)
 
@@ -385,31 +414,32 @@ def run(argv: list[str] | None = None):
             )
 
         body_locations = []
-        with BuildSketch(mode=Mode.PRIVATE) as label_sketch:
-            all_labels = []
-            for labels in batched(args.labels, args.divisions):
-                body_locations.append((0, y))
+        child_pcomps = []
+        batch_iter = batched(args.labels, args.divisions)
+        for ba in batch_iter:
+            labels = ba
+            xy = Location([0, y])
+            body_locations.append((0, y))
+            with Locations([xy]):
                 try:
-                    all_labels.append(
-                        render_divided_label(
+                    ch_pc = render_divided_label(
                             labels,
                             label_area,
                             divisions=args.divisions,
                             options=options,
-                        ).locate(Location([0, y]))
-                    )
+                        )
+                    ch_pc.locate(xy)
+                    ch_pc.label = "Label_" + str(len(child_pcomps)+1)
+                    child_pcomps.append(ch_pc)
+
                 except fragments.InvalidFragmentSpecification as e:
                     rich.print(f"\n[y][b]Could not proceed: {e}[/b][/y]\n")
                     sys.exit(1)
-                y -= y_offset_each_label
-            logger.debug("Combining all labels")
-            add(all_labels)
+            y -= y_offset_each_label
 
-        if args.box and is_2d:
-            logger.debug("Generating label outline for --box")
-            with BuildSketch(mode=Mode.PRIVATE) as body_box:
-                with Locations(body_locations):
-                    add(RectangleRounded(label_area.X, label_area.Y, label_area.Y / 10))
+        label_compound = Compound(children=child_pcomps)
+        label_compound.label = "Label"
+        logger.debug(f"LABEL COMPOUND {label_compound}\n{label_compound.show_topology()}")
 
         if not is_2d:
             # Create all of the bases
@@ -418,67 +448,84 @@ def run(argv: list[str] | None = None):
                 with Locations(body_locations):
                     add(body.part)
 
-            logger.debug("Extruding labels")
-            if args.style == LabelStyle.DEBOSSED:
-                extrude(label_sketch.sketch, amount=-args.depth, mode=Mode.SUBTRACT)
+    if args.box and is_2d:
+        logger.debug("Generating label outline for --box")
+        with BuildSketch(mode=Mode.PRIVATE) as body_box_bsketch:
+            with Locations(body_locations):
+                RectangleRounded(label_area.X, label_area.Y, label_area.Y / 10)
+        body_box_sketch = body_box_bsketch.sketch
+
+    base_part = base_bpart.part
 
     if not is_2d:
-        part.part.label = "Base"
-        part.part.color = Color(args.base_color)
-
+        logger.debug(f"BASE PART {base_part}\n{base_part.show_topology()}")
         if args.style == LabelStyle.DEBOSSED:
-            assembly = Compound(children=[part.part])
+            # this produces "UserWarning: Unknown Compound type, color not set"; I don't know why
+            base_part -= label_compound
+            assembly = Compound(children=[base_part])
         else:
-            embedded_or_embossed_label = extrude(label_sketch.sketch, amount=(args.depth if args.style == LabelStyle.EMBOSSED else -args.depth))
-            embedded_or_embossed_label.label = "Label"
-            embedded_or_embossed_label.color = Color(args.label_color)
-            assembly = Compound(children=[part.part, embedded_or_embossed_label])
+            assembly = Compound(children=[base_part, label_compound])
+        base_part.label = "Base"
+        base_part.color = Color(args.base_color)
 
     for output in args.output:
         if output.endswith(".stl"):
             logger.info(f"Writing STL {output}")
-            bd.export_stl(assembly, output)
+            export_stl(assembly, output)
         elif output.endswith(".step"):
             logger.info(f"Writing STEP {output}")
             export_step(assembly, output)
         elif output.endswith(".svg"):
             max_dimension = max(
-                *label_sketch.sketch.bounding_box().size, label_area.X, label_area.Y
+                *label_compound.bounding_box().size, label_area.X, label_area.Y
             )
             exporter = ExportSVG(scale=100 / max_dimension)
-            exporter.add_layer("Shapes", fill_color=Color(args.label_color), line_weight=0)
 
             if args.box and is_2d:
-                exporter.add_layer("Box", line_weight=1)
-                exporter.add_shape(body_box.sketch, layer="Box")
+                exporter.add_layer("Box", line_color=Color(args.base_color), line_weight=1)
+                exporter.add_shape(body_box_sketch, layer="Box")
+            if args.svg_mono:
+                exporter.add_layer("Shapes", fill_color=Color(args.label_color), line_weight=0)
+                compound_in_plane = label_compound.intersect(Plane.XY)
+                exporter.add_shape(compound_in_plane, layer="Shapes")
+            else:
+                layer_dict = {}
+                for pdex, part in enumerate(colored_parts(label_compound)):
+                    color = part.color
+                    color_str = str(color)
+                    if not color_str in layer_dict:
+                        exporter.add_layer(name=color_str, fill_color=color, line_weight=0)
+                        layer_dict[color_str] = True
+                    part_in_plane = part.intersect(Plane.XY)
+                    exporter.add_shape(part_in_plane, layer=color_str)
             logger.info(f"Writing SVG {output}")
-            exporter.add_shape(label_sketch.sketch, layer="Shapes")
             exporter.write(output)
         else:
             logger.error(f"Error: Do not understand output format '{args.output}'")
 
     if args.vscode:
         if is_2d:
-            show_parts.append(label_sketch.sketch)
+            show(label_compound)
         else:
             # Export both step and stl in vscode_ocp mode
-            logger.info("Writing SVG label.stl")
+            logger.info("Writing STL label.stl")
             bd.export_stl(assembly, "label.stl")
             logger.info("Writing STEP label.step")
             export_step(assembly, "label.step")
 
             if args.style != LabelStyle.DEBOSSED:
-                show(part.part, embedded_or_embossed_label, colors=[args.base_color, args.label_color])
+                # CAD viewer notices the Part colors
+                show(assembly)
             else:
                 # Split the base for display as two colours
                 show_parts = []
                 show_cols = []
-                top = part.part.split(Plane.XY.offset(-args.depth), keep=Keep.TOP)
+                top = base_part.split(Plane.XY.offset(-args.depth), keep=Keep.TOP)
                 if top:
                     show_parts.append(top)
                     show_cols.append(args.base_color)
                 if args.base != "none":
-                    bottom = part.part.split(Plane.XY, keep=Keep.BOTTOM)
+                    bottom = base_part.split(Plane.XY, keep=Keep.BOTTOM)
                     if bottom:
                         show_parts.append(bottom)
                         show_cols.append(args.label_color)

--- a/src/gflabel/fragments.py
+++ b/src/gflabel/fragments.py
@@ -21,6 +21,7 @@ from build123d import (
     BuildSketch,
     CenterArc,
     Circle,
+    Color,
     EllipticalCenterArc,
     GridLocations,
     Line,
@@ -1239,6 +1240,27 @@ class AlignmentFragment(Fragment):
         raise InvalidFragmentSpecification(
             "Got Alignment fragment ({<} or {>}) not at the start of a label; for selective alignment please pad with {...}, or specify alignment in column division."
         )
+
+
+class ModifierFragment(Fragment):
+    """This Fragment subclass is for fragments that make some kind of inline adjustment applicable to fragments that follow it. Each line of a label starts with defaults, as if no modifier fragment has yet been seen."""
+
+@fragment("color")
+class ColorFragment(ModifierFragment):
+    """Changes the color to be used for subsequent fragments on a line."""
+
+    examples = ["{color(blue)}BLUE{color(green)}GREEN]"]
+
+    def __init__(self, color_name: str):
+        self.color = color_name
+
+    visible = False
+    # a tiny, tiny circle for a microscopic bounding box, which in any case is invisible
+    # this eliminates some tedious special cases in single line processing
+    def render(self, height: float, maxsize: float, options: RenderOptions) -> Sketch:
+        with BuildSketch() as sketch:
+            Circle(0.000000000001)
+        return sketch.sketch
 
 
 @fragment("magnet", examples=["{magnet}"])

--- a/src/gflabel/label.py
+++ b/src/gflabel/label.py
@@ -8,24 +8,29 @@ import logging
 import re
 
 from build123d import (
+    BuildPart,
     BuildSketch,
+    Compound,
     Location,
     Locations,
     Mode,
     Sketch,
     Vector,
     add,
+    extrude,
 )
 from rich import print
 
 from . import fragments
-from .options import RenderOptions
+from .options import RenderOptions, LabelStyle
 from .util import IndentingRichHandler, batched
 
 logger = logging.getLogger(__name__)
 
 RE_FRAGMENT = re.compile(r"((?<!{){[^{}]+})")
 
+# We extrude fragments into Parts at the very lowest level. We
+# aggregate them into Compounds (with children) move up the stack.
 
 def _spec_to_fragments(spec: str) -> list[fragments.Fragment]:
     """Convert a single line spec string to a list of renderable fragments."""
@@ -57,7 +62,7 @@ class LabelRenderer:
     def __init__(self, options: RenderOptions):
         self.opts = options
 
-    def render(self, spec: str, area: Vector) -> Sketch:
+    def render(self, spec: str, area: Vector) -> Compound:
         """
         Given a specification string, render a single label.
 
@@ -66,7 +71,7 @@ class LabelRenderer:
             area: The width and height the label should be confined to.
 
         Returns:
-            A rendered Sketch object with the label contents, centered on
+            A rendered Compound object with the label contents, centered on
             the origin.
         """
         # Area splitting
@@ -132,22 +137,22 @@ class LabelRenderer:
         logger.debug(f"{column_widths=}")
         logger.debug(f"{column_proportions=}")
 
-        with BuildSketch(mode=Mode.PRIVATE) as sketch:
-            x = -area.X / 2
-            for column_spec, width in zip(columns, column_widths):
-                add(
-                    self._do_multiline_render(
-                        column_spec, Vector(X=width, Y=area.Y)
-                    ).locate(Location((x + (width / 2), 0)))
-                )
-                x += width + self.opts.column_gap
+        child_pcomps = []
+        x = -area.X / 2
+        for column_spec, width in zip(columns, column_widths):
+            xy = Location(((x + (width / 2), 0)))
+            with Locations([xy]):
+                  ch_pc = self._do_multiline_render(column_spec, Vector(X=width, Y=area.Y))
+                  ch_pc.locate(xy)
+                  ch_pc.label = "Multiline_" + str(len(child_pcomps)+1)
+                  child_pcomps.append(ch_pc)
+            x += width + self.opts.column_gap
 
-        return sketch.sketch
-        # return self._do_multiline_render(spec, area)
+        compound = Compound(children=child_pcomps)
+        return compound
 
     def _do_multiline_render(
-        self, spec: str, area: Vector, is_rescaling: bool = False
-    ) -> Sketch:
+        self, spec: str, area: Vector, is_rescaling: bool = False) -> Compound:
         """Label render function, with ability to recurse."""
         lines = spec.splitlines()
         if spec.endswith("\n"):
@@ -156,43 +161,45 @@ class LabelRenderer:
         if not lines:
             raise ValueError("Asked to render empty label")
 
-        row_height = (area.Y - (self.opts.line_spacing_mm * (len(lines) - 1))) / len(
-            lines
-        )
+        row_height = (area.Y - (self.opts.line_spacing_mm * (len(lines) - 1))) / len(lines)
 
-        with BuildSketch() as sketch:
-            # Render each line onto the sketch separately
-            for n, line in enumerate(lines):
-                # Handle blank lines
-                if not line:
-                    continue
-                # Calculate the y of the line center
-                render_y = (
-                    area.Y / 2
-                    - (row_height + self.opts.line_spacing_mm) * n
-                    - row_height / 2
+        child_pcomps = []
+        # Render each line into the Compound separately
+        for n, line in enumerate(lines):
+            # Handle blank lines
+            if not line:
+                continue
+            # Calculate the y of the line center
+            render_y = (
+                area.Y / 2
+                - (row_height + self.opts.line_spacing_mm) * n
+                - row_height / 2
+            )
+            logger.info(f'Rendering line {n+1} ("{line}")')
+            IndentingRichHandler.indent()
+            xy = Location((0, render_y))
+            with Locations([xy]):
+                ch_pc = self._render_single_line(
+                    line,
+                    Vector(X=area.X, Y=row_height),
+                    allow_overheight=self.opts.allow_overheight,
                 )
-                logger.info(f'Rendering line {n+1} ("{line}")')
-                IndentingRichHandler.indent()
-                with Locations([(0, render_y)]):
-                    add(
-                        self._render_single_line(
-                            line,
-                            Vector(X=area.X, Y=row_height),
-                            self.opts.allow_overheight,
-                        )
-                    )
-                IndentingRichHandler.dedent()
+                ch_pc.locate(xy)
+                ch_pc.label = "Line_" + str(len(child_pcomps)+1)
+                child_pcomps.append(ch_pc)
+            IndentingRichHandler.dedent()
 
-        scale_to_maxwidth = area.X / sketch.sketch.bounding_box().size.X
-        scale_to_maxheight = area.Y / sketch.sketch.bounding_box().size.Y
+        ml_compound = Compound(children=child_pcomps)
+        bbox = ml_compound.bounding_box()
+        scale_to_maxwidth = area.X / bbox.size.X
+        scale_to_maxheight = area.Y / bbox.size.Y
 
         if scale_to_maxheight < 1 - 1e3:
             print(
                 f"Vertical scale is too high for area ({scale_to_maxheight}); downscaling"
             )
         to_scale = min(scale_to_maxheight, scale_to_maxwidth, 1)
-        print(f"Got scale: {to_scale}")
+        print("Got scale: " + str(to_scale))
         if to_scale < 0.99 and not is_rescaling:
             print(f"Rescaling as {scale_to_maxwidth}")
             # We need to scale this down. Resort to adjusting the height and re-requesting.
@@ -205,7 +212,7 @@ class LabelRenderer:
 
             # If we had an area that didn't fill the whole height, then we need
             # to scale down THAT height, instead of the "total available" height
-            height_to_scale = min(area.Y, sketch.sketch.bounding_box().size.Y)
+            height_to_scale = min(area.Y, bbox.size.Y)
 
             second_try = self._do_multiline_render(
                 spec,
@@ -222,23 +229,50 @@ class LabelRenderer:
                 )
             print_spec = spec.replace("\n", "\\n")
             print(
-                f'Entry "{print_spec}" calculated width = {sketch.sketch.bounding_box().size.X:.1f} (max {area.X})'
+                f'Entry "{print_spec}" calculated width = {bbox.size.X:.1f} (max {area.X})'
             )
             return second_try
         print(
-            f'Entry "{spec}" calculated width = {sketch.sketch.bounding_box().size.X:.1f} (max {area.X})'
+            f'Entry "{spec}" calculated width = {bbox.size.X:.1f} (max {area.X})'
         )
 
-        return sketch.sketch
+        return ml_compound
 
     def _render_single_line(
-        self, line: str, area: Vector, allow_overheight: bool
-    ) -> Sketch:
+        self, line: str, area: Vector, allow_overheight: bool) -> Compound:
         """
         Render a single line of a labelspec.
         """
         # Firstly, split the line into a set of fragment objects
         frags = _spec_to_fragments(line)
+
+        # Now pre-process the modifier fragments and record stuff into
+        # a dictionary for later use; those modifier fragments are
+        # removed from the list of fragments
+
+        # For modifier fragments, the change needs to happen
+        # in this loop so that fragment order is preserved.
+        # If you need to reference something later, when the
+        # Sketch is extruded into a Part (which is pretty
+        # likely!), a good technique is to store info as
+        # entries in the fragment_data dictionary that gets
+        # attached to the Fragment object
+
+        current_color = self.opts.default_color
+        renderable_frags = []
+        for frag in frags:
+            if isinstance(frag, fragments.ModifierFragment):
+
+                if isinstance(frag, fragments.ColorFragment):
+                    logger.info(f"Switching to color '{frag.color}'")
+                    current_color = frag.color
+
+            else:
+                fragment_data = {}
+                fragment_data["color"] = current_color
+                frag.fragment_data = fragment_data
+                renderable_frags.append(frag)
+        frags = renderable_frags
 
         # Overheight fragments: Work out if we have any, so that we can
         # scale the total height such that they fit.
@@ -295,33 +329,54 @@ class LabelRenderer:
         if total_width > area.X:
             logger.warning("Overfull Hbox: Label is wider than available area")
 
+        child_parts = []
+        label_dict = {}
         # Assemble these onto the target
-        with BuildSketch() as sketch:
-            x = -total_width / 2
-            for fragment, frag_sketch in [(x, rendered[x]) for x in frags]:
-                fragment_width = frag_sketch.bounding_box().size.X
-                with Locations((x + fragment_width / 2, 0)):
-                    if fragment.visible:
-                        add(frag_sketch)
-                x += fragment_width
+        x = -total_width / 2
+        for fragment, frag_sketch in [(x, rendered[x]) for x in frags]:
+            fragment_width = frag_sketch.bounding_box().size.X
+            fxy = Location(((x + fragment_width / 2, 0)))
+            with Locations(fxy):
+                if fragment.visible:
+                    with BuildPart(mode=Mode.PRIVATE) as child_bpart:
+                        # EMBOSSED gets raised, DEBOSSED and EMBEDDED get lowered
+                        extrude(frag_sketch, self.opts.depth if self.opts.label_style == LabelStyle.EMBOSSED else -self.opts.depth)
+                    child_part = child_bpart.part
+                    child_part.color = fragment.fragment_data["color"]
+                    child_part.locate(fxy)
+                    fragment_class_name = fragment.__class__.__name__
+                    child_part_label = fragment_class_name.removesuffix("Fragment").removesuffix("fragment")
+                    label_count = label_dict[child_part_label] if child_part_label in label_dict else 0
+                    label_count += 1
+                    label_dict[child_part_label] = label_count
+                    child_part_label += "_" + str(label_count)
+                    if child_part.color != self.opts.default_color:
+                        child_part_label += "__" + current_color
+                    child_part.label = child_part_label
+                    child_parts.append(child_part)
+            x += fragment_width
 
-        return sketch.sketch
-
-
+        sl_compound = Compound(children=child_parts)
+        return sl_compound
+        
 def render_divided_label(
-    labels: str, area: Vector, divisions: int, options: RenderOptions
-) -> Sketch:
+    labels: str, area: Vector, divisions: int, options: RenderOptions) -> Compound:
     """
-    Create a sketch for multiple labels fitted into a single area
+    Create a Compound for multiple labels fitted into a single area
     """
     area = Vector(X=area.X - options.margin_mm * 2, Y=area.Y - options.margin_mm * 2)
     area_per_label = Vector(area.X / divisions, area.Y)
     leftmost_label_x = -area.X / 2 + area_per_label.X / 2
     renderer = LabelRenderer(options)
-    with BuildSketch() as sketch:
-        for i, label in enumerate(labels):
-            with Locations([(leftmost_label_x + i * area_per_label.X, 0)]):
-                if label.strip():
-                    add(renderer.render(label, area_per_label))
+    child_pcomps = []
+    for i, label in enumerate(labels):
+        xy = Location(((leftmost_label_x + i * area_per_label.X, 0)))
+        with Locations([xy]):
+            if label.strip():
+                ch_pc = renderer.render(label, area_per_label)
+                ch_pc.locate(xy)
+                ch_pc.label = "Division_" + str(len(child_pcomps)+1)
+                child_pcomps.append(ch_pc)
 
-    return sketch.sketch
+    div_compound = Compound(children=child_pcomps)
+    return div_compound

--- a/src/gflabel/options.py
+++ b/src/gflabel/options.py
@@ -91,6 +91,9 @@ class RenderOptions(NamedTuple):
     # like everything else?
     allow_overheight: bool = True
     column_gap: float = 0.4
+    label_style: LabelStyle = LabelStyle.EMBOSSED
+    depth: float = 0.4
+    default_color: str = "black"
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> RenderOptions:
@@ -118,4 +121,7 @@ class RenderOptions(NamedTuple):
             ),
             allow_overheight=not args.no_overheight,
             column_gap=args.column_gap,
+            label_style=args.style,
+            depth=args.depth,
+            default_color=args.label_color,
         )


### PR DESCRIPTION
This is useful not only for better visualizing, but it can help with selecting things when importing into a slicer or other tool for further manipulation.

For example, if you create a STEP file and convert it to a OBJ file (with any convenient converter tool), you can add the OBJ file to Bambu Studio, at which point Bambu Studio prompts you to map the colors in the OBJ file to filament colors. (Unfortunately, Bambu Studio doesn't preserve colors on STL, STEP, nor 3MF files at the moment. Maybe someday.)

Partial help for issue https://github.com/ndevenish/gflabel/issues/19
Solution for issue https://github.com/ndevenish/gflabel/issues/9

I discovered that this online STEP converter creates 3MF files that Bambu Studio likes (and preserves colors if the STEP file has them):

https://convert3d.org/step-to-3mf/app

A workflow could be:

  - create STEP file via gflabel, either with the default colors or your own choices for base color and label color
  - use that converter to convert the STEP file to 3MF
  - add the 3MF into Bambu Studio; you'll see the colors in the prepare tab
  - slice the plate
  - when you print the plate, Bambu studio will try to pick filaments for each color, but you can also pick whichever filaments you prefer before actually sending it to the printer

This workflow is less tedious than splitting the model to parts or objects and assigning filaments manually.

-----------------

(Sorry about the extra commits on this branch and PR. I had a few independent
changes in separate branches and accidentally combined all of them into
this branch. I took the shortest path get thingws back to where they should
have been.)