### PR TITLE
Export embossed labels as multiple parts

### DIFF
--- a/src/gflabel/cli.py
+++ b/src/gflabel/cli.py
@@ -508,6 +508,7 @@ def run(argv: list[str] | None = None):
                 show_cols.append((0.2, 0.2, 0.2))
             else:
                 # Split the base for display as two colours
+                is_embossed = args.style == LabelStyle.EMBOSSED
                 top = part.part.split(
                     Plane.XY if is_embossed else Plane.XY.offset(-args.depth),
                     keep=Keep.TOP,


### PR DESCRIPTION
Currently embossed style labels are only one part in the exported assembly. With this PR all exports include the label as multiple parts in the assembly. 

There is no change in the behavior for debossed or embedded styles.

Its now easier to print the embossed style labels in multiple colors.